### PR TITLE
fix: Add a few properties that the A1 mini sends

### DIFF
--- a/bambu_connect/utils/models.py
+++ b/bambu_connect/utils/models.py
@@ -39,6 +39,8 @@ class VTTray:
     remain: Optional[int] = None
     k: Optional[float] = None
     n: Optional[int] = None
+    cali_idx: Optional[str] = None
+
 
 @dataclass
 class AMSEntry:
@@ -68,6 +70,9 @@ class IPCam:
     ipcam_record: Optional[str] = None
     timelapse: Optional[str] = None
     mode_bits: Optional[int] = None
+    resolution: Optional[str] = None
+    tutk_server: Optional[str] = None
+
 
 @dataclass
 class LightsReport:
@@ -87,6 +92,7 @@ class UpgradeState:
     module: Optional[str] = None
     new_version_state: Optional[int] = None
     new_ver_list: Optional[List[Any]] = None
+    cur_state_code: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
I just started using bambu-connect with my A1 mini. It works well so far, except that I needed to add a few missing properties.